### PR TITLE
Set capture setting to high resolution photo quality

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -164,6 +164,8 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         // Create the AVCaptureSession.
         self.session = [[AVCaptureSession alloc] init];
 
+        self.session.sessionPreset = AVCaptureSessionPresetPhoto;
+
         // Communicate with the session and other session objects on this queue.
         self.sessionQueue = dispatch_queue_create( "session queue", DISPATCH_QUEUE_SERIAL );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "6.2.6",
+  "version": "6.2.7",
   "description": "Advanced native camera control with pre-defined aspect ratio, crop, etc",
   "author": "Ran Greenberg <rang@wix.com>",
   "nativePackage": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "6.2.7",
+  "version": "6.2.6",
   "description": "Advanced native camera control with pre-defined aspect ratio, crop, etc",
   "author": "Ran Greenberg <rang@wix.com>",
   "nativePackage": true,


### PR DESCRIPTION
This fixes the zoom issue we are seeing in our SmartInspect app for iOS.

https://trello.com/c/v3UG1yH8/278-some-zoom-incorrectly-applied-on-ios

AVCaptureSessionPresetPhoto:
Specifies capture settings suitable for high resolution photo quality output.

https://developer.apple.com/documentation/avfoundation/avcapturesessionpresetphoto

Camera app:
![img_0132](https://user-images.githubusercontent.com/920343/45465818-08b0fa80-b76b-11e8-84b7-8b745b818b7d.JPG)

Smartinspect app [BEFORE this fix]:
![img_1747](https://user-images.githubusercontent.com/920343/45465835-2aaa7d00-b76b-11e8-9ae5-7e57fb0f814c.PNG)

Smartinspect app [AFTER this fix]:
![img_1745](https://user-images.githubusercontent.com/920343/45465834-2aaa7d00-b76b-11e8-8211-48a7d3843c7e.PNG)

Note: The Camera app takes photos in a different aspect ratio (3:4) whereas the SmartInspect app takes 1:1 images. Therefore we can't expect our photos to be the same dimensions as the Camera app. But the zoom is fixed!!